### PR TITLE
Move native/HiPE compile behind a COMPILE_NATIVE_AEQUITAS flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2018-06-12
+### Changed
+- move native/HiPE compile behind a COMPILE_NATIVE_AEQUITAS flag
+
 ## [1.0.0] - 2018-05-06
 ### Added
 - outlier detection using IQR

--- a/src/aequitas_category.erl
+++ b/src/aequitas_category.erl
@@ -27,7 +27,9 @@
 %% @reference <a target="_parent" href="https://en.wikipedia.org/wiki/Interquartile_range">Interquartile range</a> (Wikipedia)
 
 -module(aequitas_category).
+-ifdef(COMPILE_NATIVE_AEQUITAS).
 -compile([native]).
+-endif.
 
 % https://gist.github.com/marcelog/97708058cd17f86326c82970a7f81d40#file-simpleproc-erl
 


### PR DESCRIPTION
We don't always have HiPE support, so lets make sure we can use the lib in all cases by not native compile unconditionally.